### PR TITLE
Clean out .DS_Store files from conferences/UCC2017 commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/vcs.xml
 .idea/www.iml
 .idea/workspace.xml
+.DS_Store


### PR DESCRIPTION
Remove .DS_Store files from export of old cac.ttu.edu/conferences pages